### PR TITLE
Enable `use_https` by default (#26)

### DIFF
--- a/compose/seafile_storage_classes.json
+++ b/compose/seafile_storage_classes.json
@@ -6,6 +6,7 @@
       "commits": {
         "backend": "s3",
         "host": "",
+        "use_https": true,
         "bucket": "seafile-commits",
         "key_id": "",
         "key": "",
@@ -14,6 +15,7 @@
       "fs": {
         "backend": "s3",
         "host": "",
+        "use_https": true,
         "bucket": "seafile-fs",
         "key_id": "",
         "key": "",
@@ -22,6 +24,7 @@
       "blocks": {
         "backend": "s3",
         "host": "",
+        "use_https": true,
         "bucket": "seafile-blocks",
         "key_id": "",
         "key": "",


### PR DESCRIPTION
seafobj does not follow HTTP -> HTTPS redirects

Closes #26