### PR TITLE
Disable buffered I/O

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,10 @@ FROM docker.seadrive.org/seafileltd/seafile-pro-mc:11.0.16
 
 COPY scripts/* /scripts
 
+# Disable buffered I/O since it can cause logs to appearch much later
+# Performance impact should be negligible
+ENV PYTHONUNBUFFERED=1
+
 ##
 # Fixes and Patches
 


### PR DESCRIPTION
Fixes #39

FYI: This is only necessary since `wait_for_mysql()` uses `print()` statements - using Python's `logging` library automatically ensures that the relevant output stream (stdout) is flushed after every log message :shrug: 